### PR TITLE
fix(cde): Support class-based solutions in code evaluation

### DIFF
--- a/environments/primeintellect/cde/code_task.py
+++ b/environments/primeintellect/cde/code_task.py
@@ -188,20 +188,36 @@ class CodeTask:
                 
                 # Get the function by name or find first callable
                 func = namespace.get(fn_name)
+
+                # If function not found directly, look for it in a class
+                if func is None:
+                    # First try to find a class and instantiate it
+                    for name, obj in namespace.items():
+                        if isinstance(obj, type) and not name.startswith('_'):
+                            # Found a class, instantiate it and get the method
+                            try:
+                                instance = obj()
+                                if hasattr(instance, fn_name):
+                                    func = getattr(instance, fn_name)
+                                    break
+                            except:
+                                pass
+
+                # If still not found, try to find any callable
                 if func is None:
                     for name, obj in namespace.items():
-                        if callable(obj) and not name.startswith('_'):
+                        if callable(obj) and not name.startswith('_') and not isinstance(obj, type):
                             func = obj
                             break
-                
+
                 if func is None:
                     logger.warning(f"Test {i}: No function found in code")
                     continue
-                
+
                 # Parse input (it's a JSON string)
                 test_input = json.loads(inputs[i])
                 expected_output = json.loads(outputs[i])
-                
+
                 # Run the function
                 if isinstance(test_input, list):
                     result = func(*test_input)


### PR DESCRIPTION
## Problem

The CDE environment could not evaluate solutions defined as classes with methods, which is a common pattern in coding problems (e.g., LeetCode-style solutions). All class-based solutions received a score of 0, even when the implementation was correct.

### Example: What Was Failing

When a model returns code structured as a class:

```python
class Solution:
    def removeTrailingZeros(self, num: str) -> str:
        i = len(num) - 1
        while i >= 0 and num[i] == '0':
            i -= 1
        return num[:i + 1]
```

The evaluator would:
- Not find `removeTrailingZeros` in the namespace (it's a method inside a class)
- Find the `Solution` class itself and try to call it directly as a function
- Fail to execute tests properly
- **Result: score = 0.0** ❌

### What Previously Worked

Only standalone function definitions worked:

```python
def removeTrailingZeros(num: str) -> str:
    i = len(num) - 1
    while i >= 0 and num[i] == '0':
        i -= 1
    return num[:i + 1]
```

**Result: score = 1.0** ✅

## Solution

Enhanced the function discovery logic to detect classes, instantiate them, and extract methods:

1. First, check if a function with the target name exists in the namespace
2. If not found, look for classes and instantiate them to access their methods
3. If still not found, fall back to finding any callable object

### Code Changes

```python
# Get the function by name or find first callable
func = namespace.get(fn_name)

# If function not found directly, look for it in a class
if func is None:
    # First try to find a class and instantiate it
    for name, obj in namespace.items():
        if isinstance(obj, type) and not name.startswith('_'):
            # Found a class, instantiate it and get the method
            try:
                instance = obj()
                if hasattr(instance, fn_name):
                    func = getattr(instance, fn_name)
                    break
            except:
                pass

# If still not found, try to find any callable
if func is None:
    for name, obj in namespace.items():
        if callable(obj) and not name.startswith('_') and not isinstance(obj, type):
            func = obj
            break
```

## Testing Results

Tested with a real task (remove trailing zeros from string):

**Before this fix:**
```json
{
  "task_id": 0,
  "score": 0.0,
  "success": false
}
```

**After this fix:**
```json
{
  "task_id": 0,
  "score": 1.0,
  "success": true,
  "model_time_seconds": 2.28
}
```

The same correct implementation now scores **1.0 instead of 0.0**.

## Compatibility

✅ **Backward compatible** - Standalone functions still work as before

✅ **New support** - Class-based solutions now work correctly

### Now Both Patterns Work

**Pattern 1: Standalone function** (previously supported)
```python
def removeTrailingZeros(num: str) -> str:
    return num.rstrip('0')
```

**Pattern 2: Class with methods** (newly supported)
```python
class Solution:
    def removeTrailingZeros(self, num: str) -> str:
        return num.rstrip('0')
```

Both patterns now receive correct scores based on test results.