### PR TITLE
fix: add fallback to answer field in sudoku and dyck language verifiers

### DIFF
--- a/environments/primeintellect/lgc/i3_logic/games/tasks/dyck_language/scripts/dyck_language_verifier.py
+++ b/environments/primeintellect/lgc/i3_logic/games/tasks/dyck_language/scripts/dyck_language_verifier.py
@@ -5,7 +5,10 @@ from i3_logic.base.verifier import Verifier
 class DyckLanguageVerifier(Verifier):
     def verify(self, data: Data, test_answer: str) -> bool:
         try:
-            full_sequence = data.metadata["full_sequence"]
+            # Try to get full_sequence, fallback to answer if not found
+            full_sequence = data.metadata.get("full_sequence")
+            if not full_sequence:
+                full_sequence = data.answer
 
             extracted_answer = self.extract_answer(test_answer)
 

--- a/environments/primeintellect/lgc/i3_logic/games/tasks/sudoku/scripts/sudoku_verifier.py
+++ b/environments/primeintellect/lgc/i3_logic/games/tasks/sudoku/scripts/sudoku_verifier.py
@@ -27,7 +27,10 @@ class SudokuVerifier(Verifier):
                             return False
             except (SyntaxError, ValueError):
                 return False
-            original_sudoku = data.metadata.get("original_sudoku", [])
+            # Try to get original_sudoku, fallback to answer if not found
+            original_sudoku = data.metadata.get("original_sudoku")
+            if not original_sudoku:
+                original_sudoku = data.answer
             if not original_sudoku:
                 return False
             if not self._is_valid_sudoku(sudoku_solution):


### PR DESCRIPTION
## Summary
- Update SudokuVerifier and DyckLanguageVerifier to add fallback support for the answer field
- Use data.answer as the reference answer when metadata fields are missing

## Changes
- **SudokuVerifier**: Fallback to `data.answer` when `original_sudoku` is not found in metadata
- **DyckLanguageVerifier**: Fallback to `data.answer` when `full_sequence` is not found in metadata

## Test Plan
- [ ] Verify sudoku verifier works correctly when original_sudoku is present
- [ ] Verify sudoku verifier works correctly when original_sudoku is missing but answer is available
- [ ] Verify dyck language verifier works correctly when full_sequence is present
- [ ] Verify dyck language verifier works correctly when full_sequence is missing but answer is available