### PR TITLE
Add 3 new high-difficulty games to OpenSpiel environment: Bridge, Ama…

### DIFF
--- a/environments/openspiel/agents/__init__.py
+++ b/environments/openspiel/agents/__init__.py
@@ -25,6 +25,10 @@ from .quoridor import QuoridorAgent
 # Single-player games
 from .game_2048 import Game2048Agent
 from .solitaire import SolitaireAgent
+# Advanced strategy games (NEW)
+from .bridge import BridgeAgent
+from .amazons import AmazonsAgent
+from .oware import OwareAgent
 
 
 # Game name -> Agent class mapping
@@ -55,6 +59,10 @@ GAME_AGENTS = {
     # Single-player games (high-quality additions)
     "2048": Game2048Agent,
     "solitaire": SolitaireAgent,
+    # Advanced strategy games (NEW)
+    "bridge": BridgeAgent,
+    "amazons": AmazonsAgent,
+    "oware": OwareAgent,
 }
 
 __all__ = ["GAME_AGENTS"]

--- a/environments/openspiel/agents/amazons.py
+++ b/environments/openspiel/agents/amazons.py
@@ -1,0 +1,64 @@
+"""Amazons Game Agent"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from base_agent import BaseGameAgent
+from typing import Dict, Any
+
+
+class AmazonsAgent(BaseGameAgent):
+    """Amazons Game Agent - Complex territorial control game"""
+    
+    @property
+    def game_name(self) -> str:
+        return "amazons"
+    
+    def get_rules(self) -> str:
+        return """AMAZONS RULES:
+Board: 10×10 grid. Each player has 4 amazons (queen-like pieces).
+Goal: Be the last player able to move.
+
+Turn structure (each move has 2 parts):
+1. Move your amazon (like a chess queen: any distance horizontally, vertically, or diagonally)
+2. Shoot an arrow from the new position (also like a queen move, blocking that square)
+
+Rules:
+- Amazons cannot move through or onto blocked squares or other amazons
+- Arrows permanently block squares (cannot be removed)
+- Players must make both moves if possible
+- You lose if you cannot make a legal move on your turn
+
+Strategy: Control territory, trap opponent's amazons, maintain mobility.
+This is a highly tactical game requiring long-term spatial planning.
+
+Move Format: Each action combines amazon movement + arrow placement.
+Example: "a4-d4-d1" means move amazon from a4 to d4, shoot arrow to d1."""
+    
+    def generate_params(self, config_id: int) -> Dict[str, Any]:
+        """
+        Amazons parameter generation
+        
+        Config variants:
+        - 0: Standard 10x10 board
+        - 1: Smaller 8x8 board (faster games)
+        - 2: 6x6 board (for quicker evaluation)
+        """
+        size_variant = config_id % 3
+        
+        if size_variant == 0:
+            board_size = 10
+        elif size_variant == 1:
+            board_size = 8
+        else:
+            board_size = 6
+        
+        return {"board_size": board_size}
+    
+    def get_mcts_config(self) -> tuple[int, int]:
+        """
+        2-player territorial control game. Very high complexity.
+        Large action space (hundreds of moves per turn in early game).
+        """
+        return (300, 30)

--- a/environments/openspiel/agents/bridge.py
+++ b/environments/openspiel/agents/bridge.py
@@ -1,0 +1,70 @@
+"""Bridge Game Agent"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from base_agent import BaseGameAgent
+from typing import Dict, Any
+
+
+class BridgeAgent(BaseGameAgent):
+    """Bridge Game Agent - 4-player card game"""
+    
+    @property
+    def game_name(self) -> str:
+        return "bridge"
+    
+    def get_rules(self) -> str:
+        return """BRIDGE RULES:
+Players: 4 players in 2 partnerships (North-South vs East-West). Uses standard 52-card deck.
+Goal: Win tricks to fulfill your contract bid.
+
+Game phases:
+1. BIDDING: Players bid to declare contract (level + suit/NT). Bids must be higher than previous.
+   - Level: 1-7 (number of tricks over 6 needed)
+   - Strain: ♣ (Clubs) < ♦ (Diamonds) < ♥ (Hearts) < ♠ (Spades) < NT (No Trump)
+   - Special bids: Pass, Double, Redouble
+   - Bidding ends after 3 consecutive passes
+
+2. PLAY: Declarer's partner (dummy) reveals cards. Declarer controls both hands.
+   - Must follow suit if possible
+   - Highest card in led suit wins (or highest trump if trump played)
+   - Winner of trick leads next
+
+Scoring: Points based on contract level, suit, and tricks won.
+Win condition: Partnership that fulfills more contracts wins overall.
+
+NOTE: This is a simplified Bridge implementation focusing on bidding strategy and trick-taking."""
+    
+    def generate_params(self, config_id: int) -> Dict[str, Any]:
+        """
+        Bridge parameter generation
+        
+        Config variants:
+        - 0: Standard rubber bridge
+        - 1: Chicago bridge (4 deals)
+        - 2: Duplicate bridge scoring
+        """
+        variant = config_id % 3
+        
+        params = {}
+        
+        if variant == 0:
+            # Rubber bridge (default)
+            params = {}
+        elif variant == 1:
+            # Chicago bridge
+            params = {"is_chicago": True}
+        else:
+            # Duplicate scoring
+            params = {"is_duplicate": True}
+        
+        return params
+    
+    def get_mcts_config(self) -> tuple[int, int]:
+        """
+        4-player card game. 52-card deck, complex bidding and play.
+        High strategic depth, imperfect information.
+        """
+        return (500, 50)

--- a/environments/openspiel/agents/oware.py
+++ b/environments/openspiel/agents/oware.py
@@ -1,0 +1,67 @@
+"""Oware Game Agent"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from base_agent import BaseGameAgent
+from typing import Dict, Any
+
+
+class OwareAgent(BaseGameAgent):
+    """Oware Game Agent - African mancala-style strategy game"""
+    
+    @property
+    def game_name(self) -> str:
+        return "oware"
+    
+    def get_rules(self) -> str:
+        return """OWARE RULES:
+Board: 2 rows of 6 pits (houses), each with 4 seeds initially. Each player owns one row.
+Goal: Capture more seeds than your opponent (>24 seeds to win).
+
+Turn structure:
+1. Pick all seeds from one of your pits
+2. Sow seeds counter-clockwise, one per pit (including opponent's pits)
+3. Capture: If last seed lands in opponent's pit with 2 or 3 total seeds, capture those seeds
+4. Continue capturing backwards if previous pits also have 2-3 seeds
+
+Rules:
+- Cannot leave opponent with no seeds (must give them a move)
+- Grand Slam: Capturing all opponent's seeds is forbidden (unless unavoidable)
+- Game ends when one player cannot move, or by mutual agreement
+
+Scoring: Player with most captured seeds wins.
+
+Strategy: Balance between sowing for position and capturing opportunities.
+Requires counting, planning multiple moves ahead, and denying opponent options.
+
+Move Format: Select pit number (0-5) from your row to sow seeds."""
+    
+    def generate_params(self, config_id: int) -> Dict[str, Any]:
+        """
+        Oware parameter generation
+        
+        Config variants:
+        - 0: Standard rules (4 seeds per pit)
+        - 1: Variant with 3 seeds per pit (faster)
+        - 2: Variant with 5 seeds per pit (longer games)
+        """
+        seed_variant = config_id % 3
+        
+        if seed_variant == 0:
+            seeds_per_house = 4  # Standard
+        elif seed_variant == 1:
+            seeds_per_house = 3  # Faster
+        else:
+            seeds_per_house = 5  # Longer
+        
+        return {"seeds_per_house": seeds_per_house}
+    
+    def get_mcts_config(self) -> tuple[int, int]:
+        """
+        2-player counting game. Medium complexity.
+        Action space: 6 moves per turn (choose which pit to sow).
+        Requires calculation of sowing patterns and captures.
+        """
+        return (1000, 100)

--- a/environments/openspiel/game_config.py
+++ b/environments/openspiel/game_config.py
@@ -61,6 +61,12 @@ AVAILABLE_GAMES = [
     # High trajectory diversity, excellent for testing spatial/sequential reasoning
     "2048",             # idx=17: Sliding tile puzzle, spatial planning, ~50-200 steps
     "solitaire",        # idx=18: Card sequencing, shuffled deck (high diversity), ~30-100 steps
+    
+    # Tier 7: Advanced strategy games (⭐⭐⭐⭐⭐) - NEW ADDITIONS
+    # High difficulty, complex strategy space, excellent quality
+    "bridge",           # idx=19: 4-player card game, bidding & trick-taking, imperfect info
+    "amazons",          # idx=20: Territorial control, queen-like moves + arrow placement
+    "oware",            # idx=21: Mancala variant, seed counting & capturing strategy
 ]
 
 # Notes on game changes:


### PR DESCRIPTION
Add 3 new high-difficulty games to OpenSpiel environment: Bridge, Amazons, and Oware

- Add Bridge (4-player card game): Complex bidding and trick-taking strategy with imperfect information. Supports 3 variants (standard/Chicago/duplicate). MCTS config: (500, 50)
- Add Amazons (territorial control game): Queen-like movement + arrow placement on 6x6/8x8/10x10 boards. High strategic depth with massive action space. MCTS config: (300, 30)
- Add Oware (Mancala variant): African strategy game requiring precise counting and capture planning. Supports 3-5 seeds per house variants. MCTS config: (1000, 100)

All games meet criteria:
- High difficulty (far beyond tic-tac-toe level)
- High quality (mature OpenSpiel implementations)
- High trajectory diversity (prevent strategy memorization)
- Suitable for LLM evaluation

Files changed:
- game_config.py: Added 3 games to AVAILABLE_GAMES (idx 19-21)
- agents/__init__.py: Registered 3 new agent classes
- agents/bridge.py: New BridgeAgent implementation
- agents/amazons.py: New AmazonsAgent implementation
- agents/oware.py: New OwareAgent implementation