### PR TITLE
Optimize new games: balance difficulty with computation time and clea…

### DIFF
--- a/environments/openspiel/agents/amazons.py
+++ b/environments/openspiel/agents/amazons.py
@@ -17,48 +17,48 @@ class AmazonsAgent(BaseGameAgent):
     
     def get_rules(self) -> str:
         return """AMAZONS RULES:
-Board: 10×10 grid. Each player has 4 amazons (queen-like pieces).
+Board: Grid with 4 amazons per player.
 Goal: Be the last player able to move.
 
-Turn structure (each move has 2 parts):
-1. Move your amazon (like a chess queen: any distance horizontally, vertically, or diagonally)
-2. Shoot an arrow from the new position (also like a queen move, blocking that square)
+Turn structure (2 parts per move):
+1. Move one amazon (like chess queen: any distance horizontally/vertically/diagonally)
+2. Shoot arrow from new position (also like queen move)
 
-Rules:
-- Amazons cannot move through or onto blocked squares or other amazons
-- Arrows permanently block squares (cannot be removed)
-- Players must make both moves if possible
-- You lose if you cannot make a legal move on your turn
+Constraints:
+- Cannot move through or onto blocked squares or other amazons
+- Arrows permanently block squares
+- Must complete both parts if possible
+- Lose if no legal move available
 
-Strategy: Control territory, trap opponent's amazons, maintain mobility.
-This is a highly tactical game requiring long-term spatial planning.
-
-Move Format: Each action combines amazon movement + arrow placement.
-Example: "a4-d4-d1" means move amazon from a4 to d4, shoot arrow to d1."""
+Winning: Last player able to move wins."""
     
     def generate_params(self, config_id: int) -> Dict[str, Any]:
         """
         Amazons parameter generation
         
         Config variants:
-        - 0: Standard 10x10 board
-        - 1: Smaller 8x8 board (faster games)
-        - 2: 6x6 board (for quicker evaluation)
+        - 0: 6x6 board (default - balances difficulty and speed)
+        - 1: 8x8 board (higher difficulty)
+        - 2: 10x10 board (maximum difficulty, may be slow)
+        
+        Note: Default changed to 6x6 to control computation time
+        while maintaining strategic depth.
         """
         size_variant = config_id % 3
         
         if size_variant == 0:
-            board_size = 10
+            board_size = 6
         elif size_variant == 1:
             board_size = 8
         else:
-            board_size = 6
+            board_size = 10
         
         return {"board_size": board_size}
     
     def get_mcts_config(self) -> tuple[int, int]:
         """
-        2-player territorial control game. Very high complexity.
-        Large action space (hundreds of moves per turn in early game).
+        2-player territorial control. 6x6 default board reduces action space.
+        Early game: ~50-100 moves. Late game: ~5-20 moves.
+        Reduced from (300,30) to match smaller default board size.
         """
-        return (300, 30)
+        return (200, 20)

--- a/environments/openspiel/agents/bridge.py
+++ b/environments/openspiel/agents/bridge.py
@@ -17,25 +17,25 @@ class BridgeAgent(BaseGameAgent):
     
     def get_rules(self) -> str:
         return """BRIDGE RULES:
-Players: 4 players in 2 partnerships (North-South vs East-West). Uses standard 52-card deck.
-Goal: Win tricks to fulfill your contract bid.
+Players: 4 players in 2 partnerships (North-South vs East-West). 52-card deck.
+Goal: Win tricks to fulfill contract bid.
 
-Game phases:
-1. BIDDING: Players bid to declare contract (level + suit/NT). Bids must be higher than previous.
-   - Level: 1-7 (number of tricks over 6 needed)
-   - Strain: ♣ (Clubs) < ♦ (Diamonds) < ♥ (Hearts) < ♠ (Spades) < NT (No Trump)
-   - Special bids: Pass, Double, Redouble
-   - Bidding ends after 3 consecutive passes
+BIDDING PHASE:
+- Bid format: Level (1-7) + Strain (♣/♦/♥/♠/NT)
+- Level = tricks over 6 required
+- Strain ranking: ♣ < ♦ < ♥ < ♠ < NT
+- Each bid must be higher than previous
+- Special bids: Pass, Double, Redouble
+- Bidding ends after 3 consecutive passes
 
-2. PLAY: Declarer's partner (dummy) reveals cards. Declarer controls both hands.
-   - Must follow suit if possible
-   - Highest card in led suit wins (or highest trump if trump played)
-   - Winner of trick leads next
+PLAY PHASE:
+- Declarer's partner (dummy) reveals all cards
+- Declarer controls both hands
+- Must follow suit if possible
+- Highest card in led suit wins (or highest trump)
+- Winner leads next trick
 
-Scoring: Points based on contract level, suit, and tricks won.
-Win condition: Partnership that fulfills more contracts wins overall.
-
-NOTE: This is a simplified Bridge implementation focusing on bidding strategy and trick-taking."""
+Winning: Fulfill contract (win required tricks). Partnership with most fulfilled contracts wins."""
     
     def generate_params(self, config_id: int) -> Dict[str, Any]:
         """
@@ -65,6 +65,7 @@ NOTE: This is a simplified Bridge implementation focusing on bidding strategy an
     def get_mcts_config(self) -> tuple[int, int]:
         """
         4-player card game. 52-card deck, complex bidding and play.
-        High strategic depth, imperfect information.
+        Imperfect information. Bidding phase is fast, play phase is moderate.
+        Reduced from (500,50) to balance difficulty vs computation time.
         """
-        return (500, 50)
+        return (200, 30)

--- a/environments/openspiel/agents/oware.py
+++ b/environments/openspiel/agents/oware.py
@@ -17,26 +17,21 @@ class OwareAgent(BaseGameAgent):
     
     def get_rules(self) -> str:
         return """OWARE RULES:
-Board: 2 rows of 6 pits (houses), each with 4 seeds initially. Each player owns one row.
-Goal: Capture more seeds than your opponent (>24 seeds to win).
+Board: 2 rows of 6 pits. Each player owns one row. Seeds distributed initially.
+Goal: Capture more than half of all seeds.
 
-Turn structure:
-1. Pick all seeds from one of your pits
-2. Sow seeds counter-clockwise, one per pit (including opponent's pits)
-3. Capture: If last seed lands in opponent's pit with 2 or 3 total seeds, capture those seeds
-4. Continue capturing backwards if previous pits also have 2-3 seeds
+Turn:
+1. Pick all seeds from one of your pits (0-5)
+2. Sow counter-clockwise, one seed per pit (including opponent's pits)
+3. If last seed lands in opponent's pit with 2-3 total seeds, capture them
+4. Continue capturing backwards while pits have 2-3 seeds
 
-Rules:
-- Cannot leave opponent with no seeds (must give them a move)
-- Grand Slam: Capturing all opponent's seeds is forbidden (unless unavoidable)
-- Game ends when one player cannot move, or by mutual agreement
+Constraints:
+- Cannot leave opponent with no seeds
+- Cannot capture all opponent's seeds at once (Grand Slam)
+- Game ends when player cannot move
 
-Scoring: Player with most captured seeds wins.
-
-Strategy: Balance between sowing for position and capturing opportunities.
-Requires counting, planning multiple moves ahead, and denying opponent options.
-
-Move Format: Select pit number (0-5) from your row to sow seeds."""
+Winning: Player with most captured seeds wins."""
     
     def generate_params(self, config_id: int) -> Dict[str, Any]:
         """
@@ -60,8 +55,8 @@ Move Format: Select pit number (0-5) from your row to sow seeds."""
     
     def get_mcts_config(self) -> tuple[int, int]:
         """
-        2-player counting game. Medium complexity.
-        Action space: 6 moves per turn (choose which pit to sow).
-        Requires calculation of sowing patterns and captures.
+        2-player counting game. Action space: 6 moves per turn.
+        Much simpler than Go (5x5) which uses (300,30).
+        Reduced from (1000,100) to match complexity level.
         """
-        return (1000, 100)
+        return (300, 30)


### PR DESCRIPTION
### 1. Bridge (idx=19)
**Type**: 4-player card game with partnerships and imperfect information

**Features**:
- Complex bidding phase followed by trick-taking play
- Requires probability reasoning and partnership coordination
- 3 configuration variants (standard/Chicago/duplicate scoring)

**Configuration**:
- MCTS: (200, 30) = 6,000 compute units
- Task IDs: 1900000000 + config_id (0-2)

**Why This Game**:
- High strategic depth from bidding + trick-taking combination
- Imperfect information prevents strategy memorization
- Well-established game with mature OpenSpiel implementation

---

### 2. Amazons (idx=20)
**Type**: 2-player territorial control game

**Features**:
- Each move combines amazon movement + arrow placement
- Queen-like movement pattern (horizontal/vertical/diagonal)
- 3 board sizes: 6x6 (default), 8x8, 10x10

**Configuration**:
- Default board: 6x6 (optimized for speed while maintaining difficulty)
- MCTS: (200, 20) = 4,000 compute units
- Task IDs: 2000000000 + config_id (0-2)

**Why This Game**:
- High tactical complexity requiring long-term planning
- Large strategy space even on 6x6 board
- Balances difficulty with computation time

---

### 3. Oware (idx=21)
**Type**: 2-player African Mancala variant

**Features**:
- Seed sowing and capturing mechanics
- Requires precise counting and multi-step planning
- 3 variants: 3/4/5 seeds per house

**Configuration**:
- MCTS: (300, 30) = 9,000 compute units
- Task IDs: 2100000000 + config_id (0-2)

**Why This Game**:
- Medium-high difficulty requiring calculation and foresight
- Clean action space (6 moves per turn)
- Distinct from existing games in the environment

---

## Optimization Details

### Objective 1: Balance Difficulty vs Computation Time

All MCTS configurations have been calibrated to game complexity:

| Game | Action Space | MCTS Config | Compute Units | Rationale |
|------|--------------|-------------|---------------|-----------|
| **Bridge** | ~40 | (200, 30) | 6,000 | 4-player + imperfect info |
| **Amazons 6x6** | ~80 | (200, 20) | 4,000 | Matches Chess complexity |
| **Oware** | 6 | (300, 30) | 9,000 | Matches Go 5x5 complexity |

**Comparison with existing games**:
- Leduc Poker (3 actions): 1,000,000 units
- Chess (4674 actions): 4,000 units
- Go 5x5 (25 actions): 9,000 units

All new games fit within these established ranges.

---

### Objective 2: Clean Evaluation Prompts

**Removed from all game rules**:
- ❌ Strategy hints (e.g., "Control territory, trap opponent's amazons")
- ❌ Meta-commentary (e.g., "This is a highly tactical game...")
- ❌ Format examples (e.g., "a4-d4-d1 means move amazon...")
- ❌ Evaluation notes (e.g., "NOTE: This evaluation has...")

**Kept only essential information**:
- ✅ Core game mechanics (how pieces move, how turns work)
- ✅ Win conditions (what determines victory)
- ✅ Action constraints (what you cannot do)
- ✅ Turn structure (sequence of actions)

**Philosophy**: If the LLM cannot complete the task, it's a capability issue, not a prompt issue. The rules provide complete information without hand-holding.

---

## Game Selection Criteria

All games meet the strict requirements:

### 1. High Difficulty ✅
- **Bridge**: Complex bidding + trick-taking far beyond simple card games
- **Amazons**: Territorial strategy with massive branching factor
- **Oware**: Requires multi-step calculation and foresight

### 2. High Quality ✅
- All games are mature, well-tested OpenSpiel implementations
- Clear rules with no ambiguity
- Established game theory and strategic principles

### 3. High Trajectory Diversity ✅
- **Bridge**: 52-card deck randomness + bidding combinations
- **Amazons**: Exponential strategy space even on 6x6 board
- **Oware**: Seed distribution creates varied game states

### 4. Suitable for LLM Evaluation ✅
- Clear state representation
- Discrete action spaces
- Deterministic rules (except card shuffling)
- Reasonable game length
