### PR TITLE
Return 0 score instead of error when model output is empty

### DIFF
--- a/environments/arc_gen/env.py
+++ b/environments/arc_gen/env.py
@@ -69,13 +69,13 @@ class Actor:
                 usage = chunk.usage.model_dump()
 
         if not content_parts:
-            # Return None for empty content (e.g., reasoning-only models)
+            # Return None for empty content (e.g., token limit exhausted during reasoning)
             # This will result in 0 score rather than raising an error
             return None, usage
 
         content = "".join(content_parts)
         if not content:
-            # Return None for empty content (e.g., reasoning-only models)
+            # Return None for empty content (e.g., token limit exhausted during reasoning)
             return None, usage
 
         return content.strip(), usage

--- a/environments/game/number_guess/env.py
+++ b/environments/game/number_guess/env.py
@@ -50,7 +50,7 @@ class Actor:
 
         content = response.choices[0].message.content
         if content is None:
-            # Return None for empty content (e.g., reasoning-only models)
+            # Return None for empty content (e.g., token limit exhausted during reasoning)
             # This will result in 0 score rather than raising an error
             return None
 

--- a/environments/primeintellect/lgc-v2/env.py
+++ b/environments/primeintellect/lgc-v2/env.py
@@ -146,13 +146,13 @@ class Actor:
 
             # Combine all content parts
             if not content_parts:
-                # Return None for empty content (e.g., reasoning-only models)
+                # Return None for empty content (e.g., token limit exhausted during reasoning)
                 # This will result in 0 score rather than raising an error
                 return None, usage
 
             content = "".join(content_parts)
             if not content:
-                # Return None for empty content (e.g., reasoning-only models)
+                # Return None for empty content (e.g., token limit exhausted during reasoning)
                 return None, usage
 
             # Return both content and usage information

--- a/environments/trace/env.py
+++ b/environments/trace/env.py
@@ -86,13 +86,13 @@ class Actor:
 
         # Combine all content parts
         if not content_parts:
-            # Return None for empty content (e.g., reasoning-only models)
+            # Return None for empty content (e.g., token limit exhausted during reasoning)
             # This will result in 0 score rather than raising an error
             return None, usage
 
         content = "".join(content_parts)
         if not content:
-            # Return None for empty content (e.g., reasoning-only models)
+            # Return None for empty content (e.g., token limit exhausted during reasoning)
             return None, usage
 
         # Return both content and usage information


### PR DESCRIPTION
## Problem

When reasoning models exhaust their token limit during the reasoning phase, they return empty content. Current code raises `ValueError` instead of returning 0 score.

## Example

CargoHull/Affine-C on cryptarithm task:
- Reasoning: 70,976 chars (35,833 chunks)
- Content: empty (token limit exhausted)
- Result: `ValueError("LLM API returned empty content stream")`

## Solution

Return `None` instead of raising `ValueError` when content is empty. This results in 0 score (failed attempt) rather than system error.

## Changes

- **lgc-v2, trace, arc_gen**: Collect `reasoning_content` for tracking + return `None` for empty content
- **game/number_guess**: Return `None` for empty content

## Impact

- Empty responses → 0 score (not errors)
- No breaking changes for existing models