### PR TITLE
feat: add boolean_expressions task type for lgc-v2

### DIFF
--- a/environments/primeintellect/lgc-v2/games/boolean_expressions/__init__.py
+++ b/environments/primeintellect/lgc-v2/games/boolean_expressions/__init__.py
@@ -1,0 +1,6 @@
+"""Boolean Expressions Task"""
+
+from .generator import BooleanExpressionsGenerator
+from .verifier import BooleanExpressionsVerifier
+
+__all__ = ["BooleanExpressionsGenerator", "BooleanExpressionsVerifier"]

--- a/environments/primeintellect/lgc-v2/games/boolean_expressions/config.py
+++ b/environments/primeintellect/lgc-v2/games/boolean_expressions/config.py
@@ -1,0 +1,858 @@
+"""
+Boolean Expressions Task - Configuration and Data
+
+Contains facts data, prompt templates, and parameter derivation.
+"""
+
+import random
+
+# ============================================================================
+# Common Sense Facts (Fixed lists)
+# ============================================================================
+
+COMMON_SENSE_TRUE_EN = [
+    "The Earth revolves around the Sun.",
+    "Water boils at 100 degrees Celsius at sea level.",
+    "The human body has 206 bones.",
+    "Oxygen is necessary for human survival.",
+    "Sound cannot travel through a vacuum.",
+    "Diamonds are made of carbon.",
+    "Antarctica is the coldest continent.",
+    "A day on Earth is 24 hours.",
+    "Humans have five fingers on each hand.",
+    "The Pacific Ocean is the largest ocean.",
+    "Light travels faster than sound.",
+    "The Moon orbits the Earth.",
+    "Ice is less dense than liquid water.",
+    "Plants produce oxygen through photosynthesis.",
+    "The speed of light is approximately 300,000 km/s.",
+]
+
+COMMON_SENSE_FALSE_EN = [
+    "The Sun revolves around the Earth.",
+    "Humans have three lungs.",
+    "Spiders are insects.",
+    "Sharks are mammals.",
+    "Penguins can fly.",
+    "The Great Wall of China was built in one year.",
+    "Electricity flows faster than light.",
+    "Sound travels faster in a vacuum.",
+    "The human body has 150 bones.",
+    "Mars is the closest planet to the Sun.",
+    "Whales are fish.",
+    "Bats are blind.",
+    "Lightning never strikes the same place twice.",
+    "The Moon produces its own light.",
+    "Humans only use 10% of their brain.",
+]
+
+COMMON_SENSE_TRUE_CN = [
+    "地球绕太阳运转。",
+    "水在海平面上的沸点是100摄氏度。",
+    "人体有206块骨头。",
+    "氧气对人类生存是必需的。",
+    "声音无法在真空中传播。",
+    "钻石由碳元素组成。",
+    "南极洲是最冷的大陆。",
+    "地球上一天是24小时。",
+    "人类每只手有五个手指。",
+    "太平洋是最大的海洋。",
+    "光速比声速快。",
+    "月球绕地球运转。",
+    "冰的密度比液态水小。",
+    "植物通过光合作用产生氧气。",
+    "光速约为每秒30万公里。",
+]
+
+COMMON_SENSE_FALSE_CN = [
+    "太阳绕地球运转。",
+    "人类有三个肺。",
+    "蜘蛛是昆虫。",
+    "鲨鱼是哺乳动物。",
+    "企鹅能飞翔。",
+    "中国长城是在一年内建成的。",
+    "电流比光速更快。",
+    "声音在真空中传播更快。",
+    "人体有150块骨头。",
+    "火星是距离太阳最近的行星。",
+    "鲸鱼是鱼类。",
+    "蝙蝠是瞎的。",
+    "闪电不会两次击中同一个地方。",
+    "月球自己发光。",
+    "人类只使用了大脑的10%。",
+]
+
+# ============================================================================
+# Geography Data (Template-based generation)
+# ============================================================================
+
+# Country -> Capital mapping
+CAPITALS = {
+    "France": "Paris",
+    "Japan": "Tokyo",
+    "China": "Beijing",
+    "Germany": "Berlin",
+    "Italy": "Rome",
+    "Spain": "Madrid",
+    "Russia": "Moscow",
+    "Brazil": "Brasilia",
+    "India": "New Delhi",
+    "Australia": "Canberra",
+    "Canada": "Ottawa",
+    "Mexico": "Mexico City",
+    "Egypt": "Cairo",
+    "South Korea": "Seoul",
+    "Argentina": "Buenos Aires",
+    "Turkey": "Ankara",
+    "Thailand": "Bangkok",
+    "Vietnam": "Hanoi",
+    "Poland": "Warsaw",
+    "Netherlands": "Amsterdam",
+    "Sweden": "Stockholm",
+    "Norway": "Oslo",
+    "Denmark": "Copenhagen",
+    "Finland": "Helsinki",
+    "Greece": "Athens",
+    "Portugal": "Lisbon",
+    "Austria": "Vienna",
+    "Switzerland": "Bern",
+    "Belgium": "Brussels",
+    "Ireland": "Dublin",
+    "New Zealand": "Wellington",
+    "Singapore": "Singapore",
+    "Malaysia": "Kuala Lumpur",
+    "Indonesia": "Jakarta",
+    "Philippines": "Manila",
+    "Nigeria": "Abuja",
+    "Kenya": "Nairobi",
+    "Morocco": "Rabat",
+    "Chile": "Santiago",
+    "Colombia": "Bogota",
+    "Peru": "Lima",
+    "Venezuela": "Caracas",
+    "Cuba": "Havana",
+    "Czech Republic": "Prague",
+    "Hungary": "Budapest",
+    "Romania": "Bucharest",
+    "Ukraine": "Kyiv",
+    "Saudi Arabia": "Riyadh",
+}
+
+CAPITALS_CN = {
+    "法国": "巴黎",
+    "日本": "东京",
+    "中国": "北京",
+    "德国": "柏林",
+    "意大利": "罗马",
+    "西班牙": "马德里",
+    "俄罗斯": "莫斯科",
+    "巴西": "巴西利亚",
+    "印度": "新德里",
+    "澳大利亚": "堪培拉",
+    "加拿大": "渥太华",
+    "墨西哥": "墨西哥城",
+    "埃及": "开罗",
+    "韩国": "首尔",
+    "阿根廷": "布宜诺斯艾利斯",
+    "土耳其": "安卡拉",
+    "泰国": "曼谷",
+    "越南": "河内",
+    "波兰": "华沙",
+    "荷兰": "阿姆斯特丹",
+    "瑞典": "斯德哥尔摩",
+    "挪威": "奥斯陆",
+    "丹麦": "哥本哈根",
+    "芬兰": "赫尔辛基",
+    "希腊": "雅典",
+    "葡萄牙": "里斯本",
+    "奥地利": "维也纳",
+    "瑞士": "伯尔尼",
+    "比利时": "布鲁塞尔",
+    "爱尔兰": "都柏林",
+    "新西兰": "惠灵顿",
+    "新加坡": "新加坡",
+    "马来西亚": "吉隆坡",
+    "印度尼西亚": "雅加达",
+    "菲律宾": "马尼拉",
+    "尼日利亚": "阿布贾",
+    "肯尼亚": "内罗毕",
+    "摩洛哥": "拉巴特",
+    "智利": "圣地亚哥",
+    "哥伦比亚": "波哥大",
+    "秘鲁": "利马",
+    "委内瑞拉": "加拉加斯",
+    "古巴": "哈瓦那",
+    "捷克": "布拉格",
+    "匈牙利": "布达佩斯",
+    "罗马尼亚": "布加勒斯特",
+    "乌克兰": "基辅",
+    "沙特阿拉伯": "利雅得",
+}
+
+# ============================================================================
+# Science Data (Element symbols)
+# ============================================================================
+
+ELEMENTS = {
+    "Gold": "Au",
+    "Silver": "Ag",
+    "Iron": "Fe",
+    "Copper": "Cu",
+    "Zinc": "Zn",
+    "Lead": "Pb",
+    "Tin": "Sn",
+    "Mercury": "Hg",
+    "Platinum": "Pt",
+    "Sodium": "Na",
+    "Potassium": "K",
+    "Calcium": "Ca",
+    "Magnesium": "Mg",
+    "Aluminum": "Al",
+    "Carbon": "C",
+    "Nitrogen": "N",
+    "Oxygen": "O",
+    "Hydrogen": "H",
+    "Helium": "He",
+    "Neon": "Ne",
+    "Chlorine": "Cl",
+    "Sulfur": "S",
+    "Phosphorus": "P",
+    "Silicon": "Si",
+    "Nickel": "Ni",
+    "Cobalt": "Co",
+    "Chromium": "Cr",
+    "Manganese": "Mn",
+    "Titanium": "Ti",
+    "Uranium": "U",
+}
+
+ELEMENTS_CN = {
+    "金": "Au",
+    "银": "Ag",
+    "铁": "Fe",
+    "铜": "Cu",
+    "锌": "Zn",
+    "铅": "Pb",
+    "锡": "Sn",
+    "汞": "Hg",
+    "铂": "Pt",
+    "钠": "Na",
+    "钾": "K",
+    "钙": "Ca",
+    "镁": "Mg",
+    "铝": "Al",
+    "碳": "C",
+    "氮": "N",
+    "氧": "O",
+    "氢": "H",
+    "氦": "He",
+    "氖": "Ne",
+    "氯": "Cl",
+    "硫": "S",
+    "磷": "P",
+    "硅": "Si",
+    "镍": "Ni",
+    "钴": "Co",
+    "铬": "Cr",
+    "锰": "Mn",
+    "钛": "Ti",
+    "铀": "U",
+}
+
+# ============================================================================
+# Time Data
+# ============================================================================
+
+DAYS_IN_MONTH = {
+    "January": 31,
+    "February": 28,  # Non-leap year
+    "March": 31,
+    "April": 30,
+    "May": 31,
+    "June": 30,
+    "July": 31,
+    "August": 31,
+    "September": 30,
+    "October": 31,
+    "November": 30,
+    "December": 31,
+}
+
+DAYS_IN_MONTH_CN = {
+    "一月": 31,
+    "二月": 28,
+    "三月": 31,
+    "四月": 30,
+    "五月": 31,
+    "六月": 30,
+    "七月": 31,
+    "八月": 31,
+    "九月": 30,
+    "十月": 31,
+    "十一月": 30,
+    "十二月": 31,
+}
+
+# Leap years from 1900-2100
+LEAP_YEARS = {year for year in range(1904, 2100, 4) if (year % 100 != 0 or year % 400 == 0)}
+
+# ============================================================================
+# Math Data (Primes for fact generation)
+# ============================================================================
+
+PRIMES_UNDER_100 = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97}
+
+# Perfect squares
+PERFECT_SQUARES = {i * i for i in range(1, 20)}  # 1, 4, 9, 16, ..., 361
+
+# Fibonacci numbers under 1000
+FIBONACCI_NUMBERS = {1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987}
+
+# ============================================================================
+# Astronomy Data
+# ============================================================================
+
+# Planet order from Sun (1-indexed)
+PLANET_ORDER = {
+    "Mercury": 1,
+    "Venus": 2,
+    "Earth": 3,
+    "Mars": 4,
+    "Jupiter": 5,
+    "Saturn": 6,
+    "Uranus": 7,
+    "Neptune": 8,
+}
+
+PLANET_ORDER_CN = {
+    "水星": 1,
+    "金星": 2,
+    "地球": 3,
+    "火星": 4,
+    "木星": 5,
+    "土星": 6,
+    "天王星": 7,
+    "海王星": 8,
+}
+
+# ============================================================================
+# Biology Data
+# ============================================================================
+
+# Animal legs count
+ANIMAL_LEGS = {
+    "spider": 8,
+    "ant": 6,
+    "dog": 4,
+    "cat": 4,
+    "bird": 2,
+    "human": 2,
+    "snake": 0,
+    "fish": 0,
+    "octopus": 8,
+    "crab": 10,
+    "butterfly": 6,
+    "horse": 4,
+    "elephant": 4,
+    "kangaroo": 2,
+    "frog": 4,
+    "chicken": 2,
+    "cow": 4,
+    "pig": 4,
+    "duck": 2,
+    "lobster": 10,
+}
+
+ANIMAL_LEGS_CN = {
+    "蜘蛛": 8,
+    "蚂蚁": 6,
+    "狗": 4,
+    "猫": 4,
+    "鸟": 2,
+    "人类": 2,
+    "蛇": 0,
+    "鱼": 0,
+    "章鱼": 8,
+    "螃蟹": 10,
+    "蝴蝶": 6,
+    "马": 4,
+    "大象": 4,
+    "袋鼠": 2,
+    "青蛙": 4,
+    "鸡": 2,
+    "牛": 4,
+    "猪": 4,
+    "鸭子": 2,
+    "龙虾": 10,
+}
+
+# Animal classification
+MAMMALS = {"dog", "cat", "whale", "dolphin", "bat", "elephant", "lion", "tiger", "bear", "human", "horse", "cow", "pig", "sheep", "rabbit", "mouse", "kangaroo", "koala"}
+MAMMALS_CN = {"狗", "猫", "鲸鱼", "海豚", "蝙蝠", "大象", "狮子", "老虎", "熊", "人类", "马", "牛", "猪", "羊", "兔子", "老鼠", "袋鼠", "考拉"}
+
+BIRDS = {"eagle", "sparrow", "penguin", "ostrich", "owl", "parrot", "crow", "duck", "chicken", "peacock", "flamingo", "swan"}
+BIRDS_CN = {"鹰", "麻雀", "企鹅", "鸵鸟", "猫头鹰", "鹦鹉", "乌鸦", "鸭子", "鸡", "孔雀", "火烈鸟", "天鹅"}
+
+REPTILES = {"snake", "lizard", "crocodile", "turtle", "gecko", "iguana", "chameleon", "alligator"}
+REPTILES_CN = {"蛇", "蜥蜴", "鳄鱼", "乌龟", "壁虎", "鬣蜥", "变色龙", "短吻鳄"}
+
+FISH = {"salmon", "tuna", "shark", "goldfish", "cod", "herring", "carp", "trout"}
+FISH_CN = {"三文鱼", "金枪鱼", "鲨鱼", "金鱼", "鳕鱼", "鲱鱼", "鲤鱼", "鳟鱼"}
+
+INSECTS = {"ant", "bee", "butterfly", "mosquito", "fly", "beetle", "grasshopper", "dragonfly", "cockroach", "ladybug"}
+INSECTS_CN = {"蚂蚁", "蜜蜂", "蝴蝶", "蚊子", "苍蝇", "甲虫", "蚱蜢", "蜻蜓", "蟑螂", "瓢虫"}
+
+# ============================================================================
+# History Data
+# ============================================================================
+
+HISTORICAL_EVENTS = {
+    "World War I ended": 1918,
+    "World War II ended": 1945,
+    "The first moon landing": 1969,
+    "The Berlin Wall fell": 1989,
+    "The French Revolution began": 1789,
+    "Christopher Columbus reached America": 1492,
+    "The United States declared independence": 1776,
+    "The Soviet Union dissolved": 1991,
+    "World War I began": 1914,
+    "World War II began": 1939,
+    "The first airplane flight by the Wright Brothers": 1903,
+    "The Titanic sank": 1912,
+    "The first iPhone was released": 2007,
+    "The first Olympic Games of modern era": 1896,
+    "The Great Fire of London": 1666,
+}
+
+HISTORICAL_EVENTS_CN = {
+    "第一次世界大战结束": 1918,
+    "第二次世界大战结束": 1945,
+    "人类首次登月": 1969,
+    "柏林墙倒塌": 1989,
+    "法国大革命开始": 1789,
+    "哥伦布到达美洲": 1492,
+    "美国宣布独立": 1776,
+    "苏联解体": 1991,
+    "第一次世界大战开始": 1914,
+    "第二次世界大战开始": 1939,
+    "莱特兄弟首次飞行": 1903,
+    "泰坦尼克号沉没": 1912,
+    "第一部iPhone发布": 2007,
+    "现代奥运会首届举办": 1896,
+    "伦敦大火": 1666,
+}
+
+# ============================================================================
+# Physics Data
+# ============================================================================
+
+# States of matter at room temperature (20°C)
+STATES_OF_MATTER = {
+    "water": "liquid",
+    "ice": "solid",
+    "steam": "gas",
+    "iron": "solid",
+    "gold": "solid",
+    "mercury": "liquid",
+    "oxygen": "gas",
+    "nitrogen": "gas",
+    "carbon dioxide": "gas",
+    "wood": "solid",
+    "oil": "liquid",
+    "alcohol": "liquid",
+    "helium": "gas",
+    "copper": "solid",
+    "silver": "solid",
+    "diamond": "solid",
+    "air": "gas",
+}
+
+STATES_OF_MATTER_CN = {
+    "水": "液体",
+    "冰": "固体",
+    "水蒸气": "气体",
+    "铁": "固体",
+    "金": "固体",
+    "汞": "液体",
+    "氧气": "气体",
+    "氮气": "气体",
+    "二氧化碳": "气体",
+    "木头": "固体",
+    "油": "液体",
+    "酒精": "液体",
+    "氦气": "气体",
+    "铜": "固体",
+    "银": "固体",
+    "钻石": "固体",
+    "空气": "气体",
+}
+
+STATE_NAMES_EN = ["solid", "liquid", "gas"]
+STATE_NAMES_CN = ["固体", "液体", "气体"]
+
+# ============================================================================
+# Extended Geography Data
+# ============================================================================
+
+# Countries and their continents
+COUNTRY_CONTINENT = {
+    "China": "Asia",
+    "Japan": "Asia",
+    "India": "Asia",
+    "France": "Europe",
+    "Germany": "Europe",
+    "Italy": "Europe",
+    "Brazil": "South America",
+    "Argentina": "South America",
+    "United States": "North America",
+    "Canada": "North America",
+    "Mexico": "North America",
+    "Australia": "Oceania",
+    "Egypt": "Africa",
+    "South Africa": "Africa",
+    "Nigeria": "Africa",
+    "Russia": "Europe",
+    "United Kingdom": "Europe",
+    "Spain": "Europe",
+    "Thailand": "Asia",
+    "Vietnam": "Asia",
+    "South Korea": "Asia",
+    "Indonesia": "Asia",
+    "Saudi Arabia": "Asia",
+    "Kenya": "Africa",
+    "Morocco": "Africa",
+    "Chile": "South America",
+    "Colombia": "South America",
+    "Peru": "South America",
+    "New Zealand": "Oceania",
+}
+
+COUNTRY_CONTINENT_CN = {
+    "中国": "亚洲",
+    "日本": "亚洲",
+    "印度": "亚洲",
+    "法国": "欧洲",
+    "德国": "欧洲",
+    "意大利": "欧洲",
+    "巴西": "南美洲",
+    "阿根廷": "南美洲",
+    "美国": "北美洲",
+    "加拿大": "北美洲",
+    "墨西哥": "北美洲",
+    "澳大利亚": "大洋洲",
+    "埃及": "非洲",
+    "南非": "非洲",
+    "尼日利亚": "非洲",
+    "俄罗斯": "欧洲",
+    "英国": "欧洲",
+    "西班牙": "欧洲",
+    "泰国": "亚洲",
+    "越南": "亚洲",
+    "韩国": "亚洲",
+    "印度尼西亚": "亚洲",
+    "沙特阿拉伯": "亚洲",
+    "肯尼亚": "非洲",
+    "摩洛哥": "非洲",
+    "智利": "南美洲",
+    "哥伦比亚": "南美洲",
+    "秘鲁": "南美洲",
+    "新西兰": "大洋洲",
+}
+
+CONTINENTS_EN = ["Asia", "Europe", "Africa", "North America", "South America", "Oceania", "Antarctica"]
+CONTINENTS_CN = ["亚洲", "欧洲", "非洲", "北美洲", "南美洲", "大洋洲", "南极洲"]
+
+# ============================================================================
+# Currency Data
+# ============================================================================
+
+COUNTRY_CURRENCY = {
+    "United States": "Dollar",
+    "Japan": "Yen",
+    "United Kingdom": "Pound",
+    "European Union": "Euro",
+    "China": "Yuan",
+    "India": "Rupee",
+    "Russia": "Ruble",
+    "Brazil": "Real",
+    "Australia": "Dollar",
+    "Canada": "Dollar",
+    "Switzerland": "Franc",
+    "South Korea": "Won",
+    "Mexico": "Peso",
+    "Singapore": "Dollar",
+    "Thailand": "Baht",
+    "Malaysia": "Ringgit",
+    "Indonesia": "Rupiah",
+    "Philippines": "Peso",
+    "Vietnam": "Dong",
+    "South Africa": "Rand",
+    "Turkey": "Lira",
+    "Saudi Arabia": "Riyal",
+    "Egypt": "Pound",
+    "Nigeria": "Naira",
+    "Argentina": "Peso",
+    "Chile": "Peso",
+    "Colombia": "Peso",
+    "Peru": "Sol",
+    "Sweden": "Krona",
+    "Norway": "Krone",
+    "Denmark": "Krone",
+    "Poland": "Zloty",
+    "Czech Republic": "Koruna",
+    "Hungary": "Forint",
+    "Israel": "Shekel",
+    "New Zealand": "Dollar",
+}
+
+COUNTRY_CURRENCY_CN = {
+    "美国": "美元",
+    "日本": "日元",
+    "英国": "英镑",
+    "欧盟": "欧元",
+    "中国": "人民币",
+    "印度": "卢比",
+    "俄罗斯": "卢布",
+    "巴西": "雷亚尔",
+    "澳大利亚": "澳元",
+    "加拿大": "加元",
+    "瑞士": "瑞士法郎",
+    "韩国": "韩元",
+    "墨西哥": "比索",
+    "新加坡": "新加坡元",
+    "泰国": "泰铢",
+    "马来西亚": "林吉特",
+    "印度尼西亚": "印尼盾",
+    "菲律宾": "比索",
+    "越南": "越南盾",
+    "南非": "兰特",
+    "土耳其": "里拉",
+    "沙特阿拉伯": "里亚尔",
+    "埃及": "埃及镑",
+    "尼日利亚": "奈拉",
+    "阿根廷": "比索",
+    "智利": "比索",
+    "哥伦比亚": "比索",
+    "秘鲁": "索尔",
+    "瑞典": "克朗",
+    "挪威": "克朗",
+    "丹麦": "克朗",
+    "波兰": "兹罗提",
+    "捷克": "克朗",
+    "匈牙利": "福林",
+    "以色列": "谢克尔",
+    "新西兰": "新西兰元",
+}
+
+# ============================================================================
+# Sports/Olympics Data
+# ============================================================================
+
+OLYMPICS_HOST_CITIES = {
+    1896: "Athens",
+    1900: "Paris",
+    1904: "St. Louis",
+    1908: "London",
+    1912: "Stockholm",
+    1920: "Antwerp",
+    1924: "Paris",
+    1928: "Amsterdam",
+    1932: "Los Angeles",
+    1936: "Berlin",
+    1948: "London",
+    1952: "Helsinki",
+    1956: "Melbourne",
+    1960: "Rome",
+    1964: "Tokyo",
+    1968: "Mexico City",
+    1972: "Munich",
+    1976: "Montreal",
+    1980: "Moscow",
+    1984: "Los Angeles",
+    1988: "Seoul",
+    1992: "Barcelona",
+    1996: "Atlanta",
+    2000: "Sydney",
+    2004: "Athens",
+    2008: "Beijing",
+    2012: "London",
+    2016: "Rio de Janeiro",
+    2020: "Tokyo",
+    2024: "Paris",
+}
+
+OLYMPICS_HOST_CITIES_CN = {
+    1896: "雅典",
+    1900: "巴黎",
+    1904: "圣路易斯",
+    1908: "伦敦",
+    1912: "斯德哥尔摩",
+    1920: "安特卫普",
+    1924: "巴黎",
+    1928: "阿姆斯特丹",
+    1932: "洛杉矶",
+    1936: "柏林",
+    1948: "伦敦",
+    1952: "赫尔辛基",
+    1956: "墨尔本",
+    1960: "罗马",
+    1964: "东京",
+    1968: "墨西哥城",
+    1972: "慕尼黑",
+    1976: "蒙特利尔",
+    1980: "莫斯科",
+    1984: "洛杉矶",
+    1988: "首尔",
+    1992: "巴塞罗那",
+    1996: "亚特兰大",
+    2000: "悉尼",
+    2004: "雅典",
+    2008: "北京",
+    2012: "伦敦",
+    2016: "里约热内卢",
+    2020: "东京",
+    2024: "巴黎",
+}
+
+# ============================================================================
+# Prompt Templates
+# ============================================================================
+
+PROMPTS_EN = [
+    "Evaluate the following boolean expressions and select the ones that are true:\n\n{options}\n\nWhich options evaluate to True? List all true option labels separated by commas. Put your final answer in \\boxed{{}}.",
+    "Consider the following logical expressions:\n\n{options}\n\nDetermine which expressions are true. List all true option labels separated by commas in \\boxed{{}}.",
+    "Analyze these boolean expressions:\n\n{options}\n\nWhich of these evaluate to True? Provide all true option labels separated by commas in \\boxed{{}}.",
+    "Below are several boolean expressions:\n\n{options}\n\nIdentify all expressions that are true. Answer with the option labels separated by commas in \\boxed{{}}.",
+    "Evaluate each expression below:\n\n{options}\n\nList all options that evaluate to True, separated by commas, in \\boxed{{}}.",
+    "Study the following logical statements:\n\n{options}\n\nWhich statements are true? Put all true option labels in \\boxed{{}}, separated by commas.",
+    "Here are some boolean expressions to evaluate:\n\n{options}\n\nFind all expressions that are True. Answer in \\boxed{{}} with labels separated by commas.",
+    "Examine these expressions:\n\n{options}\n\nWhich ones are true? List the labels of all true options in \\boxed{{}}, separated by commas.",
+    "Given the following boolean expressions:\n\n{options}\n\nSelect all that evaluate to True. Put your answer in \\boxed{{}} as comma-separated labels.",
+    "Review these logical expressions:\n\n{options}\n\nWhich expressions are true? Answer with comma-separated labels in \\boxed{{}}.",
+]
+
+PROMPTS_CN = [
+    "请评估以下布尔表达式，选择其中为真的选项：\n\n{options}\n\n哪些选项的值为真？请列出所有为真的选项标识，用逗号分隔，填入 \\boxed{{}} 中。",
+    "分析以下逻辑表达式：\n\n{options}\n\n判断哪些表达式为真。在 \\boxed{{}} 中列出所有为真的选项，用逗号分隔。",
+    "考虑以下布尔表达式：\n\n{options}\n\n哪些表达式的值为 True？请在 \\boxed{{}} 中给出答案，用逗号分隔选项标识。",
+    "下面是几个布尔表达式：\n\n{options}\n\n找出所有为真的表达式。在 \\boxed{{}} 中用逗号分隔列出选项标识。",
+    "评估以下每个表达式：\n\n{options}\n\n列出所有值为 True 的选项，在 \\boxed{{}} 中用逗号分隔。",
+    "研究以下逻辑语句：\n\n{options}\n\n哪些语句为真？在 \\boxed{{}} 中填入所有为真的选项标识，用逗号分隔。",
+    "这里有一些需要评估的布尔表达式：\n\n{options}\n\n找出所有为 True 的表达式。在 \\boxed{{}} 中给出答案，用逗号分隔。",
+    "检验这些表达式：\n\n{options}\n\n哪些是真的？在 \\boxed{{}} 中列出所有为真选项的标识，用逗号分隔。",
+    "给定以下布尔表达式：\n\n{options}\n\n选出所有值为 True 的选项。在 \\boxed{{}} 中以逗号分隔的形式给出答案。",
+    "审视以下逻辑表达式：\n\n{options}\n\n哪些表达式为真？在 \\boxed{{}} 中用逗号分隔给出答案。",
+]
+
+OPTION_LABELS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+
+# ============================================================================
+# Parameter Derivation
+# ============================================================================
+
+
+def derive_params_from_seed(seed: int) -> dict:
+    """
+    Derive all generation parameters from seed.
+
+    Args:
+        seed: Random seed
+
+    Returns:
+        dict with all parameters
+    """
+    rng = random.Random(seed)
+
+    return {
+        "depth": rng.randint(2, 6),
+        "num_options": rng.randint(3, 8),
+        "language": rng.choice(["en", "cn"]),
+        "prompt_idx": rng.randint(0, 9),
+        # Weights for different fact types
+        "fact_type_weights": [0.15, 0.25, 0.25, 0.15, 0.20],  # common, geo, math, time, science
+    }
+
+
+def get_prompts(language: str) -> list:
+    """Get prompt templates for given language."""
+    return PROMPTS_CN if language == "cn" else PROMPTS_EN
+
+
+def get_common_sense_facts(language: str) -> tuple:
+    """Get common sense facts for given language."""
+    if language == "cn":
+        return COMMON_SENSE_TRUE_CN, COMMON_SENSE_FALSE_CN
+    return COMMON_SENSE_TRUE_EN, COMMON_SENSE_FALSE_EN
+
+
+def get_capitals(language: str) -> dict:
+    """Get capitals data for given language."""
+    return CAPITALS_CN if language == "cn" else CAPITALS
+
+
+def get_elements(language: str) -> dict:
+    """Get elements data for given language."""
+    return ELEMENTS_CN if language == "cn" else ELEMENTS
+
+
+def get_days_in_month(language: str) -> dict:
+    """Get days in month data for given language."""
+    return DAYS_IN_MONTH_CN if language == "cn" else DAYS_IN_MONTH
+
+
+def get_planet_order(language: str) -> dict:
+    """Get planet order data for given language."""
+    return PLANET_ORDER_CN if language == "cn" else PLANET_ORDER
+
+
+def get_animal_legs(language: str) -> dict:
+    """Get animal legs data for given language."""
+    return ANIMAL_LEGS_CN if language == "cn" else ANIMAL_LEGS
+
+
+def get_animal_classes(language: str) -> dict:
+    """Get animal classification data for given language."""
+    if language == "cn":
+        return {
+            "mammals": MAMMALS_CN,
+            "birds": BIRDS_CN,
+            "reptiles": REPTILES_CN,
+            "fish": FISH_CN,
+            "insects": INSECTS_CN,
+        }
+    return {
+        "mammals": MAMMALS,
+        "birds": BIRDS,
+        "reptiles": REPTILES,
+        "fish": FISH,
+        "insects": INSECTS,
+    }
+
+
+def get_historical_events(language: str) -> dict:
+    """Get historical events data for given language."""
+    return HISTORICAL_EVENTS_CN if language == "cn" else HISTORICAL_EVENTS
+
+
+def get_states_of_matter(language: str) -> tuple:
+    """Get states of matter data for given language."""
+    if language == "cn":
+        return STATES_OF_MATTER_CN, STATE_NAMES_CN
+    return STATES_OF_MATTER, STATE_NAMES_EN
+
+
+def get_country_continent(language: str) -> tuple:
+    """Get country continent data for given language."""
+    if language == "cn":
+        return COUNTRY_CONTINENT_CN, CONTINENTS_CN
+    return COUNTRY_CONTINENT, CONTINENTS_EN
+
+
+def get_country_currency(language: str) -> dict:
+    """Get country currency data for given language."""
+    return COUNTRY_CURRENCY_CN if language == "cn" else COUNTRY_CURRENCY
+
+
+def get_olympics_data(language: str) -> dict:
+    """Get Olympics host cities data for given language."""
+    return OLYMPICS_HOST_CITIES_CN if language == "cn" else OLYMPICS_HOST_CITIES

--- a/environments/primeintellect/lgc-v2/games/boolean_expressions/generator.py
+++ b/environments/primeintellect/lgc-v2/games/boolean_expressions/generator.py
@@ -1,0 +1,1026 @@
+"""
+Boolean Expressions Task - Generator
+
+Generates boolean expression evaluation problems with seed-based determinism.
+"""
+
+import random
+import re
+from typing import List, Tuple, Optional
+
+from base.data import Data
+from .config import (
+    derive_params_from_seed,
+    get_prompts,
+    get_common_sense_facts,
+    get_capitals,
+    get_elements,
+    get_days_in_month,
+    get_planet_order,
+    get_animal_legs,
+    get_animal_classes,
+    get_historical_events,
+    get_states_of_matter,
+    get_country_continent,
+    get_country_currency,
+    get_olympics_data,
+    PRIMES_UNDER_100,
+    PERFECT_SQUARES,
+    FIBONACCI_NUMBERS,
+    LEAP_YEARS,
+    OPTION_LABELS,
+)
+
+
+class BooleanExpressionsGenerator:
+    """Generate boolean expression evaluation challenges with seed-based determinism."""
+
+    # All available fact types
+    FACT_TYPES = [
+        "common",       # Common sense facts
+        "geography",    # Capitals
+        "math",         # Prime, divisible, comparison, square, perfect_square, fibonacci, even_odd
+        "time",         # Days in month, leap year
+        "science",      # Element symbols
+        "astronomy",    # Planet order
+        "biology",      # Animal legs, classification
+        "history",      # Historical events
+        "physics",      # States of matter
+        "geo_extended", # Continent
+        "currency",     # Country currency
+        "sports",       # Olympics
+    ]
+
+    def __init__(self):
+        pass
+
+    def generate(self, seed: int = None, **kwargs) -> Data:
+        """
+        Generate a single boolean expressions challenge based on seed.
+
+        Args:
+            seed: Random seed for deterministic generation
+            **kwargs: Ignored, for compatibility
+
+        Returns:
+            Data object containing question, answer, and metadata
+        """
+        if seed is None:
+            seed = random.randint(0, 99_999_999)
+
+        # Derive all parameters from seed
+        params = derive_params_from_seed(seed)
+
+        # Create RNG for content generation
+        rng = random.Random(seed)
+
+        # Initialize language-specific data
+        language = params["language"]
+        self._init_language_data(language)
+
+        # Generate expressions
+        expressions = self._generate_expressions(
+            rng,
+            num_expressions=params["num_options"],
+            depth=params["depth"],
+        )
+
+        # Build options and find true ones
+        options = []
+        true_options = []
+
+        for i, (expr, value) in enumerate(expressions):
+            if i >= len(OPTION_LABELS):
+                break
+            label = OPTION_LABELS[i]
+            options.append(f"{label}. {expr}")
+            if value:
+                true_options.append(label)
+
+        # Format question
+        prompts = get_prompts(language)
+        prompt_template = prompts[params["prompt_idx"]]
+        question = prompt_template.format(options="\n".join(options))
+
+        # Build answer
+        true_options.sort()
+        answer = ",".join(true_options)
+
+        # Metadata
+        metadata = {
+            "seed": seed,
+            "language": language,
+            "depth": params["depth"],
+            "num_options": params["num_options"],
+            "true_count": len(true_options),
+            "expressions": [(expr, val) for expr, val in expressions],
+        }
+
+        return Data(
+            question=question,
+            answer=answer,
+            metadata=metadata,
+        )
+
+    def _init_language_data(self, language: str):
+        """Initialize language-specific data."""
+        self.language = language
+        self.true_facts, self.false_facts = get_common_sense_facts(language)
+        self.capitals = get_capitals(language)
+        self.elements = get_elements(language)
+        self.days_in_month = get_days_in_month(language)
+        self.planet_order = get_planet_order(language)
+        self.animal_legs = get_animal_legs(language)
+        self.animal_classes = get_animal_classes(language)
+        self.historical_events = get_historical_events(language)
+        self.states_of_matter, self.state_names = get_states_of_matter(language)
+        self.country_continent, self.continents = get_country_continent(language)
+        self.country_currency = get_country_currency(language)
+        self.olympics_data = get_olympics_data(language)
+
+        # Comparison operators text mapping
+        if language == "cn":
+            self.text_to_op = {
+                "大于": ">",
+                "小于": "<",
+                "大于等于": ">=",
+                "小于等于": "<=",
+                "等于": "==",
+                "不等于": "!=",
+            }
+        else:
+            self.text_to_op = {
+                "is greater than": ">",
+                "is less than": "<",
+                "is greater than or equal to": ">=",
+                "is less than or equal to": "<=",
+                "is equal to": "==",
+                "is not equal to": "!=",
+            }
+
+    def _generate_expressions(
+        self,
+        rng: random.Random,
+        num_expressions: int,
+        depth: int,
+    ) -> List[Tuple[str, bool]]:
+        """Generate multiple boolean expressions with their truth values."""
+        expressions = []
+        max_attempts = 100
+
+        for _ in range(num_expressions):
+            attempt = 0
+            while attempt < max_attempts:
+                expr = self._generate_boolean_expr(rng, depth)
+                value = self._evaluate_expression(expr)
+
+                # Ensure valid expression and reasonable length
+                if value is not None and len(expr) <= 500:
+                    expressions.append((expr, value))
+                    break
+                attempt += 1
+
+            # Fallback if too many failures - generate simple fact
+            if attempt >= max_attempts:
+                expr = self._generate_leaf_expr(rng)
+                value = self._evaluate_expression(expr)
+                if value is None:
+                    value = False
+                expressions.append((expr, value))
+
+        # Ensure at least one true option exists
+        if not any(val for _, val in expressions):
+            # Replace one with a simple true fact
+            idx = rng.randint(0, len(expressions) - 1)
+            true_fact = rng.choice(self.true_facts)
+            expressions[idx] = (true_fact, True)
+
+        return expressions
+
+    def _generate_boolean_expr(self, rng: random.Random, depth: int) -> str:
+        """Recursively generate a boolean expression."""
+        # Base case: generate leaf node
+        if depth <= 0 or (depth <= 2 and rng.random() < 0.3):
+            return self._generate_leaf_expr(rng)
+
+        choice = rng.random()
+
+        if choice < 0.30:
+            # NOT expression
+            sub_expr = self._generate_boolean_expr(rng, depth - 1)
+            not_count = rng.randint(1, 2)
+            prefix = "not " * not_count
+            return f"{prefix}({sub_expr})"
+
+        elif choice < 0.65:
+            # AND expression
+            left = self._generate_boolean_expr(rng, depth - 1)
+            right = self._generate_boolean_expr(rng, depth - 1)
+
+            if rng.random() < 0.3 and depth > 2:
+                middle = self._generate_boolean_expr(rng, depth - 2)
+                return f"({left}) and ({middle}) and ({right})"
+            return f"({left}) and ({right})"
+
+        else:
+            # OR expression
+            left = self._generate_boolean_expr(rng, depth - 1)
+            right = self._generate_boolean_expr(rng, depth - 1)
+
+            if rng.random() < 0.3 and depth > 2:
+                middle = self._generate_boolean_expr(rng, depth - 2)
+                return f"({left}) or ({middle}) or ({right})"
+            return f"({left}) or ({right})"
+
+    def _generate_leaf_expr(self, rng: random.Random) -> str:
+        """Generate a leaf expression (fact or comparison, no bare literals)."""
+        choice = rng.random()
+
+        if choice < 0.45:
+            # Arithmetic comparison
+            return self._generate_arithmetic_comparison(rng)
+        else:
+            # Fact expression
+            return self._generate_fact_expr(rng)
+
+    def _generate_arithmetic_comparison(self, rng: random.Random) -> str:
+        """Generate an arithmetic comparison expression."""
+        comparison_ops = [">", "<", ">=", "<=", "==", "!="]
+
+        # Generate left and right arithmetic expressions
+        left_expr = self._generate_arithmetic_expr(rng)
+        right_expr = self._generate_arithmetic_expr(rng)
+
+        # Choose comparison operator
+        cmp_op = rng.choice(comparison_ops)
+
+        # Occasionally use chain comparison (e.g., 1 < 2 < 3)
+        if rng.random() < 0.15:
+            middle_expr = self._generate_arithmetic_expr(rng)
+            chain_op = rng.choice(["<", "<="])
+            return f"({left_expr}) {chain_op} ({middle_expr}) {chain_op} ({right_expr})"
+
+        return f"({left_expr}) {cmp_op} ({right_expr})"
+
+    def _generate_arithmetic_expr(self, rng: random.Random) -> str:
+        """Generate an arithmetic expression."""
+        ops = ["+", "-", "*"]
+
+        # Simple expression: a op b
+        if rng.random() < 0.6:
+            a = rng.randint(-20, 20)
+            b = rng.randint(-20, 20)
+            op = rng.choice(ops)
+            return f"{a} {op} {b}"
+
+        # More complex: a * b op c * d
+        if rng.random() < 0.5:
+            a = rng.randint(-10, 10)
+            b = rng.randint(-10, 10)
+            c = rng.randint(-10, 10)
+            d = rng.randint(-10, 10)
+            op = rng.choice(ops)
+            return f"{a} * {b} {op} {c} * {d}"
+
+        # With power or modulo
+        if rng.random() < 0.5:
+            base = rng.randint(1, 5)
+            exp = rng.randint(1, 3)
+            return f"{base} ** {exp}"
+        else:
+            a = rng.randint(1, 50)
+            b = rng.randint(1, 10)
+            return f"{a} % {b}"
+
+    def _generate_fact_expr(self, rng: random.Random) -> str:
+        """Generate a fact expression from various categories."""
+        fact_type = rng.choice(self.FACT_TYPES)
+
+        if fact_type == "common":
+            return self._generate_common_sense_fact(rng)
+        elif fact_type == "geography":
+            return self._generate_geography_fact(rng)
+        elif fact_type == "math":
+            return self._generate_math_fact(rng)
+        elif fact_type == "time":
+            return self._generate_time_fact(rng)
+        elif fact_type == "science":
+            return self._generate_science_fact(rng)
+        elif fact_type == "astronomy":
+            return self._generate_astronomy_fact(rng)
+        elif fact_type == "biology":
+            return self._generate_biology_fact(rng)
+        elif fact_type == "history":
+            return self._generate_history_fact(rng)
+        elif fact_type == "physics":
+            return self._generate_physics_fact(rng)
+        elif fact_type == "geo_extended":
+            return self._generate_geo_extended_fact(rng)
+        elif fact_type == "currency":
+            return self._generate_currency_fact(rng)
+        elif fact_type == "sports":
+            return self._generate_sports_fact(rng)
+        else:
+            return self._generate_common_sense_fact(rng)
+
+    def _generate_common_sense_fact(self, rng: random.Random) -> str:
+        """Generate a common sense fact."""
+        if rng.random() < 0.5:
+            return rng.choice(self.true_facts)
+        else:
+            return rng.choice(self.false_facts)
+
+    def _generate_geography_fact(self, rng: random.Random) -> str:
+        """Generate a geography fact about capitals."""
+        countries = list(self.capitals.keys())
+        country = rng.choice(countries)
+        correct_capital = self.capitals[country]
+
+        if rng.random() < 0.5:
+            capital = correct_capital
+        else:
+            other_capitals = [c for c in self.capitals.values() if c != correct_capital]
+            capital = rng.choice(other_capitals)
+
+        if self.language == "cn":
+            return f"{country}的首都是{capital}。"
+        else:
+            return f"The capital of {country} is {capital}."
+
+    def _generate_math_fact(self, rng: random.Random) -> str:
+        """Generate a mathematical fact."""
+        math_type = rng.choice(["prime", "divisible", "comparison", "square", "perfect_square", "fibonacci", "even_odd"])
+
+        if math_type == "prime":
+            n = rng.randint(2, 99)
+            if self.language == "cn":
+                return f"{n}是质数。"
+            else:
+                return f"{n} is a prime number."
+
+        elif math_type == "divisible":
+            a = rng.randint(10, 100)
+            b = rng.randint(2, 12)
+            if self.language == "cn":
+                return f"{a}能被{b}整除。"
+            else:
+                return f"{a} is divisible by {b}."
+
+        elif math_type == "comparison":
+            a = rng.randint(1, 100)
+            b = rng.randint(1, 100)
+            if rng.random() < 0.5:
+                if self.language == "cn":
+                    return f"{a}大于{b}。"
+                else:
+                    return f"{a} is greater than {b}."
+            else:
+                if self.language == "cn":
+                    return f"{a}小于等于{b}。"
+                else:
+                    return f"{a} is less than or equal to {b}."
+
+        elif math_type == "square":
+            n = rng.randint(1, 15)
+            square = n * n
+            if rng.random() < 0.5:
+                claimed_root = n
+            else:
+                claimed_root = rng.randint(1, 15)
+
+            if self.language == "cn":
+                return f"{square}的平方根是{claimed_root}。"
+            else:
+                return f"The square root of {square} is {claimed_root}."
+
+        elif math_type == "perfect_square":
+            n = rng.randint(1, 400)
+            if self.language == "cn":
+                return f"{n}是完全平方数。"
+            else:
+                return f"{n} is a perfect square."
+
+        elif math_type == "fibonacci":
+            n = rng.randint(1, 1000)
+            if self.language == "cn":
+                return f"{n}是斐波那契数。"
+            else:
+                return f"{n} is a Fibonacci number."
+
+        else:  # even_odd
+            n = rng.randint(1, 200)
+            if rng.random() < 0.5:
+                if self.language == "cn":
+                    return f"{n}是偶数。"
+                else:
+                    return f"{n} is an even number."
+            else:
+                if self.language == "cn":
+                    return f"{n}是奇数。"
+                else:
+                    return f"{n} is an odd number."
+
+    def _generate_time_fact(self, rng: random.Random) -> str:
+        """Generate a time-related fact."""
+        time_type = rng.choice(["days_in_month", "leap_year"])
+
+        if time_type == "days_in_month":
+            month = rng.choice(list(self.days_in_month.keys()))
+            correct_days = self.days_in_month[month]
+
+            if rng.random() < 0.5:
+                days = correct_days
+            else:
+                days = rng.choice([28, 29, 30, 31])
+
+            if self.language == "cn":
+                return f"{month}有{days}天。"
+            else:
+                return f"There are {days} days in {month}."
+
+        else:  # leap_year
+            year = rng.randint(1900, 2100)
+
+            if self.language == "cn":
+                return f"{year}年是闰年。"
+            else:
+                return f"{year} is a leap year."
+
+    def _generate_science_fact(self, rng: random.Random) -> str:
+        """Generate a science fact about elements."""
+        elements_list = list(self.elements.keys())
+        element = rng.choice(elements_list)
+        correct_symbol = self.elements[element]
+
+        if rng.random() < 0.5:
+            symbol = correct_symbol
+        else:
+            other_symbols = [s for s in self.elements.values() if s != correct_symbol]
+            symbol = rng.choice(other_symbols)
+
+        if self.language == "cn":
+            return f"{element}的化学符号是{symbol}。"
+        else:
+            return f"The chemical symbol for {element} is {symbol}."
+
+    def _generate_astronomy_fact(self, rng: random.Random) -> str:
+        """Generate an astronomy fact about planet order."""
+        planet = rng.choice(list(self.planet_order.keys()))
+        correct_order = self.planet_order[planet]
+
+        if rng.random() < 0.5:
+            order = correct_order
+        else:
+            order = rng.randint(1, 8)
+
+        if self.language == "cn":
+            return f"{planet}是距离太阳第{order}近的行星。"
+        else:
+            return f"{planet} is the {self._ordinal(order)} planet from the Sun."
+
+    def _ordinal(self, n: int) -> str:
+        """Convert number to ordinal string."""
+        if 10 <= n % 100 <= 20:
+            suffix = "th"
+        else:
+            suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+        return f"{n}{suffix}"
+
+    def _generate_biology_fact(self, rng: random.Random) -> str:
+        """Generate a biology fact."""
+        bio_type = rng.choice(["legs", "classification"])
+
+        if bio_type == "legs":
+            animal = rng.choice(list(self.animal_legs.keys()))
+            correct_legs = self.animal_legs[animal]
+
+            if rng.random() < 0.5:
+                legs = correct_legs
+            else:
+                legs = rng.choice([0, 2, 4, 6, 8, 10, 100])
+
+            if self.language == "cn":
+                return f"{animal}有{legs}条腿。"
+            else:
+                return f"A {animal} has {legs} legs."
+
+        else:  # classification
+            class_type = rng.choice(["mammals", "birds", "reptiles", "fish", "insects"])
+            class_set = self.animal_classes[class_type]
+            animal = rng.choice(list(class_set))
+
+            # Class name in target language
+            class_names = {
+                "mammals": ("哺乳动物", "mammal"),
+                "birds": ("鸟类", "bird"),
+                "reptiles": ("爬行动物", "reptile"),
+                "fish": ("鱼类", "fish"),
+                "insects": ("昆虫", "insect"),
+            }
+
+            if rng.random() < 0.5:
+                claimed_class = class_type
+            else:
+                claimed_class = rng.choice(["mammals", "birds", "reptiles", "fish", "insects"])
+
+            cn_name, en_name = class_names[claimed_class]
+
+            if self.language == "cn":
+                return f"{animal}是{cn_name}。"
+            else:
+                article = "an" if en_name[0] in "aeiou" else "a"
+                return f"A {animal} is {article} {en_name}."
+
+    def _generate_history_fact(self, rng: random.Random) -> str:
+        """Generate a historical fact."""
+        event = rng.choice(list(self.historical_events.keys()))
+        correct_year = self.historical_events[event]
+
+        if rng.random() < 0.5:
+            year = correct_year
+        else:
+            # Generate a wrong year within reasonable range
+            year = correct_year + rng.choice([-10, -5, -2, -1, 1, 2, 5, 10])
+
+        if self.language == "cn":
+            return f"{event}发生在{year}年。"
+        else:
+            return f"{event} occurred in {year}."
+
+    def _generate_physics_fact(self, rng: random.Random) -> str:
+        """Generate a physics fact about states of matter."""
+        substance = rng.choice(list(self.states_of_matter.keys()))
+        correct_state = self.states_of_matter[substance]
+
+        if rng.random() < 0.5:
+            state = correct_state
+        else:
+            state = rng.choice(self.state_names)
+
+        if self.language == "cn":
+            return f"{substance}在常温下是{state}。"
+        else:
+            return f"{substance.capitalize()} is a {state} at room temperature."
+
+    def _generate_geo_extended_fact(self, rng: random.Random) -> str:
+        """Generate extended geography facts about continents."""
+        country = rng.choice(list(self.country_continent.keys()))
+        correct_continent = self.country_continent[country]
+
+        if rng.random() < 0.5:
+            continent = correct_continent
+        else:
+            continent = rng.choice(self.continents)
+
+        if self.language == "cn":
+            return f"{country}位于{continent}。"
+        else:
+            return f"{country} is in {continent}."
+
+    def _generate_currency_fact(self, rng: random.Random) -> str:
+        """Generate a currency fact."""
+        country = rng.choice(list(self.country_currency.keys()))
+        correct_currency = self.country_currency[country]
+
+        if rng.random() < 0.5:
+            currency = correct_currency
+        else:
+            other_currencies = [c for c in self.country_currency.values() if c != correct_currency]
+            currency = rng.choice(other_currencies)
+
+        if self.language == "cn":
+            return f"{country}的货币是{currency}。"
+        else:
+            return f"The currency of {country} is the {currency}."
+
+    def _generate_sports_fact(self, rng: random.Random) -> str:
+        """Generate a sports/Olympics fact."""
+        year = rng.choice(list(self.olympics_data.keys()))
+        correct_city = self.olympics_data[year]
+
+        if rng.random() < 0.5:
+            city = correct_city
+        else:
+            other_cities = [c for c in self.olympics_data.values() if c != correct_city]
+            city = rng.choice(other_cities)
+
+        if self.language == "cn":
+            return f"{year}年奥运会在{city}举办。"
+        else:
+            return f"The {year} Olympics were held in {city}."
+
+    def _evaluate_expression(self, expr: str) -> Optional[bool]:
+        """Evaluate a boolean expression, returning None if evaluation fails."""
+        processed = self._preprocess_expression(expr)
+        try:
+            result = eval(processed)
+            return bool(result)
+        except Exception:
+            return None
+
+    def _preprocess_expression(self, expr: str) -> str:
+        """Preprocess expression for evaluation."""
+        # Replace fact statements with their truth values
+        expr = self._replace_facts(expr)
+
+        # Replace text operators with symbols
+        sorted_text_ops = sorted(self.text_to_op.keys(), key=len, reverse=True)
+        for text in sorted_text_ops:
+            op = self.text_to_op[text]
+            expr = expr.replace(text, op)
+
+        return expr
+
+    def _replace_facts(self, expr: str) -> str:
+        """Replace fact statements with True/False."""
+        # Common sense facts
+        for fact in self.true_facts:
+            expr = expr.replace(fact, "True")
+        for fact in self.false_facts:
+            expr = expr.replace(fact, "False")
+
+        # Geography facts (capitals)
+        expr = self._replace_geography_facts(expr)
+
+        # Math facts
+        expr = self._replace_math_facts(expr)
+
+        # Time facts
+        expr = self._replace_time_facts(expr)
+
+        # Science facts (elements)
+        expr = self._replace_science_facts(expr)
+
+        # Astronomy facts
+        expr = self._replace_astronomy_facts(expr)
+
+        # Biology facts
+        expr = self._replace_biology_facts(expr)
+
+        # History facts
+        expr = self._replace_history_facts(expr)
+
+        # Physics facts
+        expr = self._replace_physics_facts(expr)
+
+        # Extended geography facts
+        expr = self._replace_geo_extended_facts(expr)
+
+        # Currency facts
+        expr = self._replace_currency_facts(expr)
+
+        # Sports facts
+        expr = self._replace_sports_facts(expr)
+
+        return expr
+
+    def _replace_geography_facts(self, expr: str) -> str:
+        """Replace geography facts with True/False."""
+        for country, capital in self.capitals.items():
+            if self.language == "cn":
+                true_fact = f"{country}的首都是{capital}。"
+            else:
+                true_fact = f"The capital of {country} is {capital}."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+的首都是[\u4e00-\u9fa5]+。"
+        else:
+            pattern = r"The capital of [A-Za-z\s]+ is [A-Za-z\s]+\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_math_facts(self, expr: str) -> str:
+        """Replace math facts with True/False."""
+        # Prime numbers
+        if self.language == "cn":
+            pattern = r"(\d+)是质数。"
+        else:
+            pattern = r"(\d+) is a prime number\."
+
+        def check_prime(match):
+            n = int(match.group(1))
+            return "True" if n in PRIMES_UNDER_100 else "False"
+        expr = re.sub(pattern, check_prime, expr)
+
+        # Divisibility
+        if self.language == "cn":
+            pattern = r"(\d+)能被(\d+)整除。"
+        else:
+            pattern = r"(\d+) is divisible by (\d+)\."
+
+        def check_divisible(match):
+            a, b = int(match.group(1)), int(match.group(2))
+            return "True" if b != 0 and a % b == 0 else "False"
+        expr = re.sub(pattern, check_divisible, expr)
+
+        # Greater than
+        if self.language == "cn":
+            pattern = r"(\d+)大于(\d+)。"
+        else:
+            pattern = r"(\d+) is greater than (\d+)\."
+
+        def check_greater(match):
+            a, b = int(match.group(1)), int(match.group(2))
+            return "True" if a > b else "False"
+        expr = re.sub(pattern, check_greater, expr)
+
+        # Less than or equal
+        if self.language == "cn":
+            pattern = r"(\d+)小于等于(\d+)。"
+        else:
+            pattern = r"(\d+) is less than or equal to (\d+)\."
+
+        def check_leq(match):
+            a, b = int(match.group(1)), int(match.group(2))
+            return "True" if a <= b else "False"
+        expr = re.sub(pattern, check_leq, expr)
+
+        # Square root
+        if self.language == "cn":
+            pattern = r"(\d+)的平方根是(\d+)。"
+        else:
+            pattern = r"The square root of (\d+) is (\d+)\."
+
+        def check_sqrt(match):
+            n, root = int(match.group(1)), int(match.group(2))
+            return "True" if root * root == n else "False"
+        expr = re.sub(pattern, check_sqrt, expr)
+
+        # Perfect square
+        if self.language == "cn":
+            pattern = r"(\d+)是完全平方数。"
+        else:
+            pattern = r"(\d+) is a perfect square\."
+
+        def check_perfect_square(match):
+            n = int(match.group(1))
+            return "True" if n in PERFECT_SQUARES else "False"
+        expr = re.sub(pattern, check_perfect_square, expr)
+
+        # Fibonacci
+        if self.language == "cn":
+            pattern = r"(\d+)是斐波那契数。"
+        else:
+            pattern = r"(\d+) is a Fibonacci number\."
+
+        def check_fibonacci(match):
+            n = int(match.group(1))
+            return "True" if n in FIBONACCI_NUMBERS else "False"
+        expr = re.sub(pattern, check_fibonacci, expr)
+
+        # Even number
+        if self.language == "cn":
+            pattern = r"(\d+)是偶数。"
+        else:
+            pattern = r"(\d+) is an even number\."
+
+        def check_even(match):
+            n = int(match.group(1))
+            return "True" if n % 2 == 0 else "False"
+        expr = re.sub(pattern, check_even, expr)
+
+        # Odd number
+        if self.language == "cn":
+            pattern = r"(\d+)是奇数。"
+        else:
+            pattern = r"(\d+) is an odd number\."
+
+        def check_odd(match):
+            n = int(match.group(1))
+            return "True" if n % 2 == 1 else "False"
+        expr = re.sub(pattern, check_odd, expr)
+
+        return expr
+
+    def _replace_time_facts(self, expr: str) -> str:
+        """Replace time facts with True/False."""
+        # Days in month
+        if self.language == "cn":
+            pattern = r"([\u4e00-\u9fa5]+月)有(\d+)天。"
+        else:
+            pattern = r"There are (\d+) days in ([A-Za-z]+)\."
+
+        def check_days(match):
+            if self.language == "cn":
+                month, days = match.group(1), int(match.group(2))
+            else:
+                days, month = int(match.group(1)), match.group(2)
+            correct = self.days_in_month.get(month, -1)
+            return "True" if days == correct else "False"
+        expr = re.sub(pattern, check_days, expr)
+
+        # Leap year
+        if self.language == "cn":
+            pattern = r"(\d+)年是闰年。"
+        else:
+            pattern = r"(\d+) is a leap year\."
+
+        def check_leap(match):
+            year = int(match.group(1))
+            return "True" if year in LEAP_YEARS else "False"
+        expr = re.sub(pattern, check_leap, expr)
+
+        return expr
+
+    def _replace_science_facts(self, expr: str) -> str:
+        """Replace science facts with True/False."""
+        for element, symbol in self.elements.items():
+            if self.language == "cn":
+                true_fact = f"{element}的化学符号是{symbol}。"
+            else:
+                true_fact = f"The chemical symbol for {element} is {symbol}."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+的化学符号是[A-Za-z]+。"
+        else:
+            pattern = r"The chemical symbol for [A-Za-z]+ is [A-Za-z]+\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_astronomy_facts(self, expr: str) -> str:
+        """Replace astronomy facts with True/False."""
+        # Planet order
+        for planet, order in self.planet_order.items():
+            if self.language == "cn":
+                true_fact = f"{planet}是距离太阳第{order}近的行星。"
+            else:
+                true_fact = f"{planet} is the {self._ordinal(order)} planet from the Sun."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining planet order as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+是距离太阳第\d+近的行星。"
+        else:
+            pattern = r"[A-Za-z]+ is the \d+(?:st|nd|rd|th) planet from the Sun\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_biology_facts(self, expr: str) -> str:
+        """Replace biology facts with True/False."""
+        # Animal legs
+        for animal, legs in self.animal_legs.items():
+            if self.language == "cn":
+                true_fact = f"{animal}有{legs}条腿。"
+            else:
+                true_fact = f"A {animal} has {legs} legs."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining legs as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+有\d+条腿。"
+        else:
+            pattern = r"A [a-z]+ has \d+ legs\."
+        expr = re.sub(pattern, "False", expr)
+
+        # Animal classification
+        class_names = {
+            "mammals": ("哺乳动物", "mammal"),
+            "birds": ("鸟类", "bird"),
+            "reptiles": ("爬行动物", "reptile"),
+            "fish": ("鱼类", "fish"),
+            "insects": ("昆虫", "insect"),
+        }
+
+        for class_type, animals in self.animal_classes.items():
+            cn_name, en_name = class_names[class_type]
+            for animal in animals:
+                if self.language == "cn":
+                    true_fact = f"{animal}是{cn_name}。"
+                else:
+                    article = "an" if en_name[0] in "aeiou" else "a"
+                    true_fact = f"A {animal} is {article} {en_name}."
+                expr = expr.replace(true_fact, "True")
+
+        # Replace remaining classification as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+是(?:哺乳动物|鸟类|爬行动物|鱼类|昆虫)。"
+        else:
+            pattern = r"A [a-z]+ is (?:a|an) (?:mammal|bird|reptile|fish|insect)\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_history_facts(self, expr: str) -> str:
+        """Replace history facts with True/False."""
+        for event, year in self.historical_events.items():
+            if self.language == "cn":
+                true_fact = f"{event}发生在{year}年。"
+            else:
+                true_fact = f"{event} occurred in {year}."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5A-Za-z]+发生在\d+年。"
+        else:
+            pattern = r".+ occurred in \d+\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_physics_facts(self, expr: str) -> str:
+        """Replace physics facts with True/False."""
+        for substance, state in self.states_of_matter.items():
+            if self.language == "cn":
+                true_fact = f"{substance}在常温下是{state}。"
+            else:
+                true_fact = f"{substance.capitalize()} is a {state} at room temperature."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+在常温下是(?:固体|液体|气体)。"
+        else:
+            pattern = r"[A-Za-z\s]+ is a (?:solid|liquid|gas) at room temperature\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_geo_extended_facts(self, expr: str) -> str:
+        """Replace extended geography facts with True/False."""
+        # Continent
+        for country, continent in self.country_continent.items():
+            if self.language == "cn":
+                true_fact = f"{country}位于{continent}。"
+            else:
+                true_fact = f"{country} is in {continent}."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining continent as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+位于[\u4e00-\u9fa5]+。"
+        else:
+            pattern = r"[A-Za-z\s]+ is in [A-Za-z\s]+\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_currency_facts(self, expr: str) -> str:
+        """Replace currency facts with True/False."""
+        for country, currency in self.country_currency.items():
+            if self.language == "cn":
+                true_fact = f"{country}的货币是{currency}。"
+            else:
+                true_fact = f"The currency of {country} is the {currency}."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining as False
+        if self.language == "cn":
+            pattern = r"[\u4e00-\u9fa5]+的货币是[\u4e00-\u9fa5]+。"
+        else:
+            pattern = r"The currency of [A-Za-z\s]+ is the [A-Za-z]+\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def _replace_sports_facts(self, expr: str) -> str:
+        """Replace sports facts with True/False."""
+        for year, city in self.olympics_data.items():
+            if self.language == "cn":
+                true_fact = f"{year}年奥运会在{city}举办。"
+            else:
+                true_fact = f"The {year} Olympics were held in {city}."
+            expr = expr.replace(true_fact, "True")
+
+        # Replace remaining as False
+        if self.language == "cn":
+            pattern = r"\d+年奥运会在[\u4e00-\u9fa5]+举办。"
+        else:
+            pattern = r"The \d+ Olympics were held in [A-Za-z\s]+\."
+        expr = re.sub(pattern, "False", expr)
+
+        return expr
+
+    def extract_answer(self, test_solution: str) -> Optional[str]:
+        """
+        Extract answer from model response.
+
+        Looks for \\boxed{} pattern and extracts content.
+        """
+        last_box_index = test_solution.rfind("\\boxed{")
+        if last_box_index == -1:
+            return None
+
+        start_index = last_box_index + len("\\boxed{")
+        bracket_stack = 1
+        end_index = start_index
+
+        while end_index < len(test_solution) and bracket_stack > 0:
+            if test_solution[end_index] == "{":
+                bracket_stack += 1
+            elif test_solution[end_index] == "}":
+                bracket_stack -= 1
+            end_index += 1
+
+        if bracket_stack != 0:
+            return None
+
+        content = test_solution[start_index:end_index - 1].strip()
+        return content

--- a/environments/primeintellect/lgc-v2/games/boolean_expressions/verifier.py
+++ b/environments/primeintellect/lgc-v2/games/boolean_expressions/verifier.py
@@ -1,0 +1,48 @@
+"""
+Boolean Expressions Task - Verifier
+
+Verifies model responses for boolean expression evaluation problems.
+"""
+
+import re
+from base.data import Data
+from base.verifier import Verifier
+
+
+class BooleanExpressionsVerifier(Verifier):
+    """Verify boolean expression evaluation answers."""
+
+    def verify(self, data: Data, test_solution: str) -> bool:
+        """
+        Verify if the solution is correct.
+
+        Args:
+            data: Game data containing correct answer
+            test_solution: Model's response
+
+        Returns:
+            bool: True if correct, False otherwise
+        """
+        try:
+            # Extract answer from response
+            from .generator import BooleanExpressionsGenerator
+
+            generator = BooleanExpressionsGenerator()
+            test_answer = generator.extract_answer(test_solution)
+
+            if test_answer is None:
+                return False
+
+            # Extract letters from both answers
+            test_letters = re.findall(r"[a-zA-Z]", test_answer)
+            ground_truth_letters = re.findall(r"[a-zA-Z]", data.answer)
+
+            # Normalize to lowercase
+            test_set = set(letter.lower() for letter in test_letters)
+            ground_truth_set = set(letter.lower() for letter in ground_truth_letters)
+
+            # Compare sets
+            return test_set == ground_truth_set
+
+        except Exception:
+            return False

--- a/environments/primeintellect/lgc-v2/games/verifiers.py
+++ b/environments/primeintellect/lgc-v2/games/verifiers.py
@@ -9,6 +9,7 @@ from games.dyck_language2.verifier import DyckLanguage2Verifier
 from games.game_of_24.verifier import GameOf24Verifier
 from games.operation.verifier import OperationVerifier
 from games.cryptarithm.verifier import CryptarithmVerifier
+from games.boolean_expressions.verifier import BooleanExpressionsVerifier
 
 # Add your verifiers here:
 # from games.your_task.verifier import YourTaskVerifier
@@ -19,6 +20,7 @@ verifier_classes = {
     "game_of_24": GameOf24Verifier,
     "operation": OperationVerifier,
     "cryptarithm": CryptarithmVerifier,
+    "boolean_expressions": BooleanExpressionsVerifier,
     # Add your verifiers here:
     # "your_task": YourTaskVerifier,
 }

--- a/environments/primeintellect/lgc-v2/logic_task_v2.py
+++ b/environments/primeintellect/lgc-v2/logic_task_v2.py
@@ -60,6 +60,12 @@ class LogicTaskV2:
             "class": "DyckLanguage2Generator",
             "default_config": {}  # n_types and length derived from seed
         },
+        "boolean_expressions": {
+            "task_type_id": 6,  # Range: 600,000,000-699,999,999
+            "module": "games.boolean_expressions.generator",
+            "class": "BooleanExpressionsGenerator",
+            "default_config": {}  # All parameters derived from seed
+        },
     }
 
     # Reverse mapping: task_type_id -> task_type_name


### PR DESCRIPTION
## Summary
- Add new `boolean_expressions` task type to lgc-v2 environment
- Evaluate nested boolean expressions combining facts and arithmetic logic
- 12 fact categories with bilingual support (EN/CN)
- task_type_id=6, supporting 100M seeds (600M-699M range)

## Features
- **Fact types**: common sense, geography (capitals), math (primes, divisibility, etc.), time (months, leap years), science (elements), astronomy (planet order), biology (animal legs, classification), history (events), physics (states of matter), geo_extended (continents), currency, sports (Olympics)
- **Expression complexity**: configurable depth 2-6, nested and/or/not operations
- **Answer format**: `\boxed{A,B,C}` with comma-separated option labels

## Test plan
- [x] Unit test: generator produces valid expressions
- [x] Unit test: verifier correctly judges answers  
- [x] E2E test: 80% success rate, 100% seed consistency/diversity